### PR TITLE
Add degress argument for rotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,15 +139,19 @@ optional arguments:
 ### Rotate
 
 ```
-usage: pdftools rotate [-h] [-c] [-p PAGES [PAGES ...]] [-o OUTPUT] src
+usage: pdftools rotate [-h] [-d {90,180,270}] [-c] [-p PAGES [PAGES ...]]
+                       [-o OUTPUT]
+                       src
 
-Rotate the pages of a PDF files by 90 degrees
+Rotate the pages of a PDF file by a set number of degrees
 
 positional arguments:
   src                   Source file
 
 optional arguments:
   -h, --help            show this help message and exit
+  -d {90,180,270}, --degrees {90,180,270}
+                        Specify degrees value to rotate page(s) (default: 90)
   -c, --counter-clockwise
                         Rotate pages counter-clockwise instead of clockwise,
                         by default (default: False)

--- a/pdftools/_cli.py
+++ b/pdftools/_cli.py
@@ -153,11 +153,19 @@ def main():
     # --------------------------------------------
     parser_rotate = SUBPARSERS.add_parser(
         "rotate",
-        help="Rotate the pages of a PDF files by 90 degrees",
-        description="Rotate the pages of a PDF files by 90 degrees",
+        help="Rotate the pages of a PDF file by a set number of degrees",
+        description="Rotate the pages of a PDF file by a set number of degrees",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser_rotate.add_argument("src", type=str, default=None, help="Source file")
+    parser_rotate.add_argument(
+        "-d",
+        "--degrees",
+        choices=(90, 180, 270),
+        default=90,
+        type=int,
+        help="Specify degrees value to rotate page(s)"
+    )
     parser_rotate.add_argument(
         "-c",
         "--counter-clockwise",
@@ -271,7 +279,7 @@ def main():
     elif ARGS.command == "rotate":
         from pdftools.pdftools import pdf_rotate
 
-        pdf_rotate(ARGS.src, ARGS.counter_clockwise, ARGS.pages, ARGS.output)
+        pdf_rotate(ARGS.src, ARGS.degrees, ARGS.counter_clockwise, ARGS.pages, ARGS.output)
     elif ARGS.command == "split":
         from pdftools.pdftools import pdf_split
 

--- a/pdftools/pdftools.py
+++ b/pdftools/pdftools.py
@@ -53,6 +53,7 @@ def pdf_merge(inputs: [str], output: str, delete: bool = False):
 
 def pdf_rotate(
     input: str,
+    degrees: int,
     counter_clockwise: bool = False,
     pages: [str] = None,
     output: str = None,
@@ -60,6 +61,7 @@ def pdf_rotate(
     """
     Rotate the given Pdf files clockwise or counter clockwise.
     :param inputs: pdf files
+    :param degrees: number of degrees to rotate the page(s)
     :param counter_clockwise: rotate counter clockwise if true else clockwise
     :param pages: list of page numbers to rotate, if None all pages will be
         rotated
@@ -79,9 +81,9 @@ def pdf_rotate(
     for i, page in enumerate(source_pages):
         if pages is None or i in pages:
             if counter_clockwise:
-                writer.addPage(page.rotateCounterClockwise(90))
+                writer.addPage(page.rotateCounterClockwise(degrees))
             else:
-                writer.addPage(page.rotateClockwise(90))
+                writer.addPage(page.rotateClockwise(degrees))
         else:
             writer.addPage(page)
 


### PR DESCRIPTION
Enables the specified page(s) in a PDF file to be rotated either 90, 180 or 270 degrees in one run, without having to make multiple calls.