### PR TITLE
Fix args for pdftools.copy

### DIFF
--- a/pdftools/_cli.py
+++ b/pdftools/_cli.py
@@ -263,7 +263,7 @@ def main():
     elif ARGS.command == "copy":
         from pdftools.pdftools import pdf_copy
 
-        pdf_copy(ARGS.input, ARGS.output, ARGS.pages, ARGS.y)
+        pdf_copy(ARGS.src, ARGS.output, ARGS.pages, ARGS.y)
     elif ARGS.command == "insert":
         from pdftools.pdftools import pdf_insert
 


### PR DESCRIPTION
I exchanged ARGS.input with ARGS.src, as this is consistent with the way the attribute is named in the other subparsers