### PR TITLE
Feature: "yes to all" for `pdftools delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ pdftools
 [![Downloads](https://pepy.tech/badge/pdftools)](https://pepy.tech/project/pdftools)
 [![Downloads](https://pepy.tech/badge/pdftools/week)](https://pepy.tech/project/pdftools/week)
 
+## local install
+
+`pip install .`
+
+do not use `setup.py install`
+
 ## Features
 
 * add, insert, remove and rotate pages

--- a/pdftools/_cli.py
+++ b/pdftools/_cli.py
@@ -148,6 +148,10 @@ def main():
         default=None,
         help="Name of the output file. If None, the `src` file will be overwritten",
     )
+    parser_remove.add_argument(
+        "-f", "--force",
+        action="store_true",
+        help='Caution!! Answers "Yes" to all overwrite queries.')
 
     # Rotate
     # --------------------------------------------
@@ -275,7 +279,7 @@ def main():
     elif ARGS.command == "remove":
         from pdftools.pdftools import pdf_remove
 
-        pdf_remove(ARGS.src, ARGS.pages, ARGS.output)
+        pdf_remove(ARGS.src, ARGS.pages, ARGS.output, ARGS.force)
     elif ARGS.command == "rotate":
         from pdftools.pdftools import pdf_rotate
 

--- a/pdftools/pdftools.py
+++ b/pdftools/pdftools.py
@@ -311,7 +311,7 @@ def pdf_insert(
     srcfile.close()
 
 
-def pdf_remove(source: str, pages: [str], output: str = None):
+def pdf_remove(source: str, pages: [str], output: str = None, yes_to_all=False):
     """
     Remove pages from a PDF source file.
     :param source: pdf source file
@@ -346,7 +346,7 @@ def pdf_remove(source: str, pages: [str], output: str = None):
 
     # Move temporary file to source
     if output is None:
-        if overwrite_dlg(source):
+        if yes_to_all or overwrite_dlg(source):
             os.remove(source)
             move(outfile.name, source)
         else:


### PR DESCRIPTION
When this package is used as a library, there are instances where the overwrite query in `delete` gets in the way.  Also, on the command line, it is useful to have a way to get around the overwrite query.

For example:
```
ls *.pdf  | xargs -I {} pdftools delete {} 1
``` 
does not remove the first page of every pdf in the cwd.  With  this PR in place, 
```
ls *.pdf  | xargs -I {} pdftools -f delete {} 1
``` 
would do the trick.